### PR TITLE
Change "request not dispatchable" to Warn from Error

### DIFF
--- a/Slim/Web/JSONRPC.pm
+++ b/Slim/Web/JSONRPC.pm
@@ -483,7 +483,8 @@ sub requestMethod {
 
 	} else {
 		$clientid ||= $playername;
-		$log->error(($clientid ? "$clientid: " : '') . "request not dispatchable!");
+		# Warn rather than Error because this does happen a lot - e.g. device at end of gateway via plugin is powered off
+		$log->warn(($clientid ? "$clientid: " : '') . "request not dispatchable!");
 		Slim::Web::HTTP::closeHTTPSocket($context->{'httpClient'});
 		return;
 	}	


### PR DESCRIPTION
This event happens a lot with some installations - for example when using one of Philippe's gateways that creates / destroys players on the fly.